### PR TITLE
Clarify 5s reveal delay removal steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,28 @@ explain exactly where to look:
   // any other reveal-related calls that were inside the timeout
   ```
 
+- If you want to be certain about what to delete, temporarily insert
+  comment markers before and after the timeout, then remove the marked block:
+
+  ```js
+  // BEGIN REMOVE (5s delay)
+  setTimeout(() => {
+    startReveal();
+    initHeroVideo();
+    preloadModel();
+  }, 5000);
+  // END REMOVE (5s delay)
+  ```
+
+  Delete everything between `BEGIN REMOVE` and `END REMOVE` (including those
+  two lines), then keep the inner calls in place:
+
+  ```js
+  startReveal();
+  initHeroVideo();
+  preloadModel();
+  ```
+
 ## Speed up media delivery
 - Provide a `poster` attribute on videos to avoid blank frames, e.g.
   `<video muted playsinline preload="metadata" poster="{{ poster | img_url: '720x' }}">`.


### PR DESCRIPTION
## Summary
- clarify what the 5-second delay refers to in the reveal behavior and why it happens
- point to common theme files and keywords where the 5s setTimeout is typically defined
- add explicit before/after guidance showing which lines to remove when deleting the 5-second timeout wrapper

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952ce63d718832fb265a6db02375828)